### PR TITLE
Fix patch script compatibility

### DIFF
--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -1,31 +1,27 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 # find all patches in patches/
 PATCHES=$(find patches/ -type f -name '*.patch')
 
-check () {
-	git apply --check -q -p1 $PATCH
-}
-
 apply () {
-	git apply -p1 $PATCH
+	git apply $PATCH
 }
 
 check_applied () {
-	git apply --check --reverse -q -p1 $PATCH
+	git apply --check --reverse -q $PATCH
 }
 
 fail () {
 	echo =======\> \'$PATCH\' was not applied && exit 1
 }
 
-if [[ -n "$PATCHES" ]];
+if [ -n "$PATCHES" ];
 then
 	# check patch validity and apply, else check if already applied and report and exit on failure
 	echo 'Patches found. Applying...';
 	for PATCH in $PATCHES;
 	do
-		check && apply || check_applied || fail;
+		apply || check_applied || fail;
 	done
 else
 	echo 'No patches found.'


### PR DESCRIPTION
Fix some compatibility issues in the patch script
1. for best compatibility we use #!/bin/sh for the shebang, because some systems do not have /bin/bash, e.g. alpine linux, freebsd, nixos
2. in the shebang we use -eu as per convention to catch typos and errors
3. for best compatibility we use posix shell syntax "[ ]" instead of bash syntax "[[ ]]"
4. no need to dry run check. git apply already runs check before applying
5. no need to use -p1. git apply already does it