### PR TITLE
Meson: install headers in hyprland subdir

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -25,7 +25,7 @@ if not features.get('session')
 endif
 
 install_subdir('wlr',
-	install_dir: get_option('includedir'),
+	install_dir: get_option('includedir') / 'hyprland',
 	exclude_files: exclude_files,
 )
 

--- a/include/wlr/meson.build
+++ b/include/wlr/meson.build
@@ -22,4 +22,4 @@ ver_h = configure_file(
 	configuration: version_data,
 )
 
-install_headers(conf_h, ver_h, subdir: 'wlr')
+install_headers(conf_h, ver_h, install_dir: get_option('includedir') / 'hyprland' / 'wlr')

--- a/meson.build
+++ b/meson.build
@@ -199,10 +199,12 @@ if get_option('examples')
 	subdir('tinywl')
 endif
 
+pkg_install_dir = join_paths(get_option('datadir'), 'pkgconfig')
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
 	lib_wlr,
 	description: 'Wayland compositor library',
+	install_dir: pkg_install_dir,
 	url: 'https://gitlab.freedesktop.org/wlroots/wlroots',
 	variables: wlr_vars,
 )


### PR DESCRIPTION
Since wlroots-hyprland is to only be used by Hyprland, we will always want to install the wlr headers in `$includedir/hyprland/wlr`.

This change will help fix the recent inconsistencies between the CMake and Meson builds of Hyprland, and the respective hyprland-plugins build failures.

Tested building as a subproject with both CMake and Meson. Also built plugins using it, and everything's working.
