### PR TITLE
backend/drm/libliftoff.c: add additional options parameter

### DIFF
--- a/patches/backend-drm-add-support-for-libliftoff-v0.5.0.patch
+++ b/patches/backend-drm-add-support-for-libliftoff-v0.5.0.patch
@@ -1,0 +1,51 @@
+From 8b1628adcf530fd5396f62479175e486126efc7c Mon Sep 17 00:00:00 2001
+From: Simon Ser <contact@emersion.fr>
+Date: Tue, 28 May 2024 00:30:33 +0200
+Subject: [PATCH] backend/drm: add support for libliftoff v0.5.0
+
+Don't require libliftoff 0.5.0 just yet: we want to be able to
+backport this patch.
+---
+ backend/drm/libliftoff.c | 5 +++++
+ backend/drm/meson.build  | 1 +
+ 2 files changed, 6 insertions(+)
+
+diff --git a/backend/drm/libliftoff.c b/backend/drm/libliftoff.c
+index c88e1bcee0..74d4f76963 100644
+--- a/backend/drm/libliftoff.c
++++ b/backend/drm/libliftoff.c
+@@ -8,6 +8,7 @@
+ #include "backend/drm/drm.h"
+ #include "backend/drm/fb.h"
+ #include "backend/drm/iface.h"
++#include "config.h"
+ 
+ static bool init(struct wlr_drm_backend *drm) {
+ 	// TODO: lower log level
+@@ -407,7 +408,11 @@ static bool commit(struct wlr_drm_backend *drm,
+ 		struct wlr_drm_connector *conn = state->connectors[i].connector;
+ 		struct wlr_drm_crtc *crtc = conn->crtc;
+ 
++#if HAVE_LIBLIFTOFF_0_5
++		int ret = liftoff_output_apply(crtc->liftoff, req, flags, NULL);
++#else
+ 		int ret = liftoff_output_apply(crtc->liftoff, req, flags);
++#endif
+ 		if (ret != 0) {
+ 			wlr_drm_conn_log(conn, test_only ? WLR_DEBUG : WLR_ERROR,
+ 				"liftoff_output_apply failed: %s", strerror(-ret));
+diff --git a/backend/drm/meson.build b/backend/drm/meson.build
+index 5d2f2b1f8c..7c00b0f085 100644
+--- a/backend/drm/meson.build
++++ b/backend/drm/meson.build
+@@ -48,6 +48,7 @@ wlr_files += files(
+ 
+ if libliftoff.found()
+ 	wlr_files += files('libliftoff.c')
++	internal_config.set10('HAVE_LIBLIFTOFF_0_5', libliftoff.version().version_compare('>=0.5.0'))
+ endif
+ 
+ features += { 'drm-backend': true }
+-- 
+GitLab
+


### PR DESCRIPTION
This fixes build with libliftoff 0.5.0
| ../git/subprojects/wlroots-hyprland/backend/drm/libliftoff.c: In function 'commit': | ../git/subprojects/wlroots-hyprland/backend/drm/libliftoff.c:410:27: error: too few arguments to function 'liftoff_output_apply'
|   410 |                 int ret = liftoff_output_apply(crtc->liftoff, req, flags);